### PR TITLE
Add percentile clipping to TIFF viewer

### DIFF
--- a/girder_sem_viewer/__init__.py
+++ b/girder_sem_viewer/__init__.py
@@ -16,7 +16,6 @@ except ImportError:
 import dateutil.parser
 import magic
 import numpy as np
-import scipy.ndimage as ndimage
 from girder import auditLogger, events
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
@@ -341,15 +340,11 @@ def get_sem_thumbnail(self, item):
                 )  # Convert back to 8-bit grayscale
 
             elif im.mode in ["I;16", "I"]:  # 16-bit or 32-bit integer grayscale
-                if item.get("meta", {}).get("KafkaTopic") == "aimdl-xrd":
-                    im = np.asarray(im)
-                    im = np.log(im - im.min() + 1e-3)
-                    im = ndimage.gaussian_filter(im, 2, mode="nearest")
-                    im = Image.fromarray(
-                        ((im - im.min()) / (im.max() - im.min()) * 255).astype("uint8")
-                    )
-                else:
-                    im = im.point(lambda i: i * (255 / max(im.getextrema())))
+                arr = np.asarray(im, dtype=np.float32)
+                p_low, p_high = np.percentile(arr, (1, 99))
+                arr = np.clip(arr, p_low, p_high)  # Clip to percentile range
+                arr = ((arr - p_low) / (p_high - p_low) * 255).astype("uint8")  # Normalize
+                im = Image.fromarray(arr)
             elif im.mode not in ["L"]:
                 im = im.convert("RGB").convert("L")
             im = im.resize((1200, 1200), Image.LANCZOS)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="girder-sem-viewer",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.3.2",
+    version="2.3.3",
     description="Girder Plugin enabling preview of SEM data.",
     packages=find_packages(),
     include_package_data=True,
@@ -24,7 +24,7 @@ setup(
     ],
     python_requires=">=3.10",
     setup_requires=["setuptools-git"],
-    install_requires=["girder>=5.0.0a5.dev0", "pillow", "python-magic", "numpy", "scipy"],
+    install_requires=["girder>=5.0.0a5.dev0", "pillow", "python-magic", "numpy"],
     entry_points={"girder.plugin": ["sem_viewer = girder_sem_viewer:SemViewerPlugin"]},
     zip_safe=False,
 )


### PR DESCRIPTION
This pull request updates the image normalization process for 16-bit and 32-bit grayscale images in the `get_sem_thumbnail` function and bumps the package version to 2.3.3. The main change standardizes how these images are processed by clipping and normalizing pixel values to improve thumbnail consistency.

**Image Processing Improvements:**

* Updated the normalization for 16-bit and 32-bit grayscale images in `get_sem_thumbnail` (in `girder_sem_viewer/__init__.py`) to always clip pixel values to the 1st–99th percentile range and scale to 8-bit, replacing the previous special-case logic for certain image types. This should yield more consistent and visually meaningful thumbnails.

**Versioning:**

* Bumped the package version from 2.3.2 to 2.3.3 in `setup.py`.